### PR TITLE
Fix "instructionText" typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ NB: By using the default parameter, and using our `DefaultStyling` struct instan
 
 ## Other Customisations
 
-A`CardScanViewModel` has a `insturctionText` property, if you wish to override the default instruction text that is shown on the viewer.
+A`CardScanViewModel` has a `instructionText` property, if you wish to override the default instruction text that is shown on the viewer.
 
 
 


### PR DESCRIPTION
## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
