### PR TITLE
Apple Privacy Manifest

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -7,25 +7,22 @@ let package = Package(
     name: "SharkCardScan",
     platforms: [ .iOS(.v13)],
     products: [
-        // Products define the executables and libraries a package produces, and make them visible to other packages.
         .library(
             name: "SharkCardScan",
             targets: ["SharkCardScan"]),
     ],
     dependencies: [
-        // Dependencies declare other packages that this package depends on.
-        // .package(url: /* package url */, from: "1.0.0"), dependencies: [
-        .package(   
+        .package(
             name: "SharkUtils",
           url: "https://github.com/gymshark/ios-shark-utils.git",
             .exact("1.0.5")),
     ],
     targets: [
-        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
-        // Targets can depend on other targets in this package, and on products in packages this package depends on.
         .target(
             name: "SharkCardScan",
-            dependencies: ["SharkUtils"]),
+            dependencies: ["SharkUtils"],
+            path: "Sources",
+            resources: [.copy("Resources/PrivacyInfo.xcprivacy")]),
         .testTarget(
             name: "SharkCardScanTests",
             dependencies: ["SharkCardScan"]),

--- a/Sources/Resources/PrivacyInfo.xcprivacy
+++ b/Sources/Resources/PrivacyInfo.xcprivacy
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypeName</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<true/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
+			</array>
+		</dict>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypePaymentInfo</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<true/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
+			</array>
+		</dict>
+	</array>
+	<key>NSPrivacyTracking</key>
+	<false/>
+</dict>
+</plist>

--- a/Sources/SharkCardScan/SharkCardScanViewController.swift
+++ b/Sources/SharkCardScan/SharkCardScanViewController.swift
@@ -15,7 +15,7 @@ public class SharkCardScanViewController: UIViewController {
     private var styling: CardScanStyling
     
     private lazy var closeButton = UIButton().with {
-        $0.setBackgroundImage(UIImage(named: "rounded close"), for: .normal)
+        $0.setBackgroundImage(UIImage(named: "rounded close", in: Bundle.module, compatibleWith: nil), for: .normal)
         $0.accessibilityLabel = String(describing: SharkCardScanViewController.self) + "." + "CloseButton"
     }
     


### PR DESCRIPTION
## Description

This PR adds new [Privacy Manifest](https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_data_use_in_privacy_manifests) according to new Apple requirements.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update